### PR TITLE
pkclient: Error handle for 'slot id' out of bounce

### DIFF
--- a/pkclient.go
+++ b/pkclient.go
@@ -49,6 +49,11 @@ func New(hsmPath string, slot uint, pin string) (*PKClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if uint(len(slots)) <= slot {
+		return nil, fmt.Errorf("Requested slot (%d) but only %d available", slot, len(slots))
+	}
+
 	// try to open a session on the slot
 	client.HSM_Session.session, err = slots[slot].OpenWriteSession()
 	if err != nil {


### PR DESCRIPTION
Common case is "slot 0", but the HSM reports no tokens

> `panic: runtime error: index out of range [0] with length 0`